### PR TITLE
parent detection robust to nested ngFor and ngIf

### DIFF
--- a/core/client-bus/src/client-bus.ts
+++ b/core/client-bus/src/client-bus.ts
@@ -431,7 +431,7 @@ export class WidgetLoader implements OnChanges {
             let parent_view = (<any> this._vc_ref)._element.parentView;
 
             const skips = ["NgForRow", "Object"]; // ngIf shows up as "Object"
-            while(skips.indexOf(parent_view.context.constructor.name) >= 0) {
+            while (skips.indexOf(parent_view.context.constructor.name) >= 0) {
               parent_view = parent_view.parentView;
             }
             const parent_widget = parent_view.context;


### PR DESCRIPTION
Widgets need to be able to access their parents. When ngFor or ngIf are used, this creates additional nesting. Previously we were hardcoding the parent->ngIf->ngFor->child pattern. This change allows the handling of nested ngIf and ngFor levels arbitrarily.