### PR TITLE
Allow png files to be copied into public folder

### DIFF
--- a/core/mean-loader/src/mean.ts
+++ b/core/mean-loader/src/mean.ts
@@ -598,7 +598,7 @@ export namespace GruntTask {
             {
               expand: true,
               cwd: "src",
-              src: ["components/**/*.{html,css,js}"],
+              src: ["components/**/*.{html,css,js,png}"],
               dest: "dist/public"
             },
             {
@@ -614,7 +614,7 @@ export namespace GruntTask {
             {
               expand: true,
               cwd: "src/dv-dev",
-              src: ["**/*.{html,css,js}"],
+              src: ["**/*.{html,css,js,png}"],
               dest: "dist/public/dv-dev"
             },
             { // the global sytle
@@ -630,7 +630,7 @@ export namespace GruntTask {
             {
               expand: true,
               cwd: "src",
-              src: ["components/**/*.{html,css,js}"],
+              src: ["components/**/*.{html,css,js,png}"],
               dest: "lib"
             }
           ]


### PR DESCRIPTION
- Ensure that you add the png file to the component of interest's folder
- If you need to add other types of images, just add them to lines 601, 617 and 633