### PR TITLE
git ignore pkg folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ dist
 lib
 tscommand-*.txt
 dv-dev
+pkg


### PR DESCRIPTION
Also, I'm curious. Why does each of the package folders have a gitignore file? That seems very redundant...