### PR TITLE
Remove name field in initial dv config

### DIFF
--- a/packages/dv-cli/src/dv.ts
+++ b/packages/dv-cli/src/dv.ts
@@ -168,7 +168,7 @@ export function installAndConfigureGateway(name: string, pathToDv: string) {
 
   console.log('Initialize dvconfig file');
   const initialConfig: DvConfig = {
-    name: name, gateway: { name: "gateway", config: { wsPort: GATEWAY_PORT } }
+    name: name, gateway: { config: { wsPort: GATEWAY_PORT } }
   };
   writeFileOrFail(
     path.join(name, DVCONFIG_FILE_PATH),


### PR DESCRIPTION
Running the migration script yielded this:
```
{
  "name": "geolocation",
  "gateway": {
    "name": "gateway",
    "config": {
      "wsPort": 3000
    }
  },
  "config": {
    "wsPort": 3001
  },
  "startServer": true
}
```
instead of:
```
{
  "name": "geolocation",
  "gateway": {
    "config": {
      "wsPort": 3000
    }
  },
  "config": {
    "wsPort": 3001
  },
  "startServer": true
}
```
