### PR TITLE
throw error if the number of cohorts is > 6

### DIFF
--- a/packages/dv-gateway/src/requestProcessor.ts
+++ b/packages/dv-gateway/src/requestProcessor.ts
@@ -52,6 +52,10 @@ interface ClicheResponse<T> {
 
 type port = string;
 
+// https://stackoverflow.com/questions/985431
+const MAX_BROWSER_CONNECTIONS = 6;
+
+
 export class RequestProcessor {
   private readonly txCoordinator: TxCoordinator<
     GatewayToClicheRequest, ClicheResponse<string>, express.Response>;
@@ -253,7 +257,6 @@ export class RequestProcessor {
               result: resp.text.result,
               payload: { status: resp.status, text: resp.text.payload }
             };
-            console.log(`Voted: ${stringify(vote)}`);
 
             return vote;
           });
@@ -312,6 +315,13 @@ export class RequestProcessor {
             return new ActionPath(nodes)
               .serialize();
           });
+
+        if (cohorts.length > MAX_BROWSER_CONNECTIONS) {
+          throw new Error(
+            `The max number of cohorts per tx is ` +
+            `${MAX_BROWSER_CONNECTIONS}. This limit will be removed in the ` +
+            `future.`);
+        }
 
         return cohorts;
       },


### PR DESCRIPTION
Browsers limit the number of active connections per domain to 6. This means that we can't have more than 6 request-sending actions in a tx. The solution is to batch all tx requests. For the time being, this PR introduces a change to throw an error if we detect that there's too many cohorts in a tx.

Depending on the app you are building, you might or might not hit the limit. If you hit the limit with an app you can try to restrict the app so that it doesn't have 100% of its functionality or move on to work on some other app.