### PR TITLE
Fix marker image bug

### DIFF
--- a/packages/catalog/geolocation/.angular-cli.json
+++ b/packages/catalog/geolocation/.angular-cli.json
@@ -11,7 +11,7 @@
         {
           "glob": "**/*",
           "input": "app/geolocation/assets/",
-          "output": "assets/"
+          "output": "assets/geolocation/"
         },
         "assets",
         "favicon.ico"

--- a/packages/catalog/geolocation/src/app/geolocation/display-map/display-map.component.ts
+++ b/packages/catalog/geolocation/src/app/geolocation/display-map/display-map.component.ts
@@ -36,8 +36,8 @@ export class DisplayMapComponent implements AfterViewInit, OnEval, OnInit,
   private _markerIcon = L.icon({
     iconSize: [25, 41],
     iconAnchor: [13, 41],
-    iconUrl: 'assets/marker-icon.png',
-    shadowUrl: 'assets/marker-shadow.png'
+    iconUrl: 'assets/geolocation/marker-icon.png',
+    shadowUrl: 'assets/geolocation/marker-shadow.png'
   });
 
   // Required

--- a/packages/language/src/app/builders/ng-app.builder.ts
+++ b/packages/language/src/app/builders/ng-app.builder.ts
@@ -116,7 +116,7 @@ export class NgAppBuilder {
 
   constructor(
     private readonly appName: string,
-    private readonly dvConfigContents: string) {}
+    private readonly dvConfigContents: string) { }
 
   addDependency(name: string, version: string): NgAppBuilder {
     this.dependencies.push({ name: name, version: version });
@@ -212,7 +212,7 @@ export class NgAppBuilder {
         .map(
           this.components,
           (c: Component) =>
-            `import { ${c.className } } from './${c.name}/${c.name}.component'`)
+            `import { ${c.className} } from './${c.name}/${c.name}.component'`)
         .join(';\n'),
       moduleImports: _
         .map(
@@ -231,7 +231,7 @@ export class NgAppBuilder {
             if (c === undefined) {
               throw new Error(
                 `Action for route "${r.path}" (${r.selector}) not found\n` +
-              `Valid actions are: ${_.keys(selectorToComponent)}`);
+                `Valid actions are: ${_.keys(selectorToComponent)}`);
             }
 
             return `{ path: "${r.path}", component: ${c} }`;
@@ -318,8 +318,9 @@ export class NgAppBuilder {
       const clichePackageLocation = path.dirname(
         require.resolve(path.join(d.name, 'package.json')));
       const clicheAssets = path.join(clichePackageLocation, 'pkg', 'assets');
+      const appAssetsDir = path.join(assetsDir, d.name);
       if (existsSync(clicheAssets)) {
-        copySync(clicheAssets, assetsDir);
+        copySync(clicheAssets, appAssetsDir);
       }
     }
 


### PR DESCRIPTION
Previously, if you clicked the map in a sample app, you would see the following instead of the marker image.
![image](https://user-images.githubusercontent.com/14367007/52233501-3d922b00-288d-11e9-9e4c-e9e87209f1de.png)

This PR changes the file paths for the images so that apps can access the images.