### PR TITLE
Fix compiler bug where outputs were used as inputs of nested actions

### DIFF
--- a/packages/compiler/src/action-input/action-input.compiler.spec.ts
+++ b/packages/compiler/src/action-input/action-input.compiler.spec.ts
@@ -1,6 +1,7 @@
 import { ActionSymbolTable } from '../symbolTable';
 import {
-  ActionInputCompiler, CompiledActionInput } from './action-input.compiler';
+  ActionInputCompiler, CompiledActionInput
+} from './action-input.compiler';
 
 
 describe('ActionInputCompiler', () => {
@@ -49,7 +50,7 @@ describe('ActionInputCompiler', () => {
     expect(compiledActionInput.action)
       .toMatch('dv.action');
     expect(compiledActionInput.action)
-      .toMatch(/event=\$.*foo.*show-bar.*loadedBar/);
+      .toMatch(/event=\$capture\_+foo\_show\_bar\_loadedBar/);
   });
 
   it('should fail with action with capture not in context', () => {
@@ -57,4 +58,23 @@ describe('ActionInputCompiler', () => {
     expect(() => actionInputCompiler.compile(actionInput, {}))
       .toThrow();
   });
+
+  it('should compile action with the output of an action as the input of ' +
+    'the innermost of two nested inputs', () => {
+      const actionInput = `
+        <authentication.logged-in />
+        <event.choose-and-show-series
+          showEvent=
+              <morg.show-group-meeting
+                groupMeeting=$event
+                loggedInIUserId=authentication.logged-in.user?.id />
+          noEventsToShowText="No meetings to show"
+          chooseSeriesSelectPlaceholder="Choose Meeting Series" />
+      `;
+
+      const compiledActionInput: CompiledActionInput = actionInputCompiler
+        .compile(actionInput, {});
+        expect(compiledActionInput.action)
+        .toMatch(/authentication\.logged\-in\.user\?\.id/);
+    });
 });

--- a/packages/compiler/src/action-input/operations/captures-to-inputs.operation.ts
+++ b/packages/compiler/src/action-input/operations/captures-to-inputs.operation.ts
@@ -77,7 +77,7 @@ export function capturesToInputs(
           if (stEntry.kind === 'cliche' || stEntry.kind === 'app') {
             const action = rest.slice(1)
               .split(NAV_SPLIT_REGEX)[0];
-            if (_.has(symbolTable, [ name, 'symbolTable', action ])) {
+            if (_.has(symbolTable, [name, 'symbolTable', action])) {
               return name + rest;
             }
           } else if (stEntry.kind === 'action') {
@@ -87,11 +87,19 @@ export function capturesToInputs(
           }
         }
         if (_.has(context, name)) {
-          const field = name + rest;
+          const action = rest.slice(1)
+            .split('.', 1)[0];
+          const memberAndOutputAccess = rest.slice(action.length + 1);
+          const [memberAccess, outputAccess] = memberAndOutputAccess.slice(1)
+            .split(NAV_SPLIT_REGEX);
+          const field = name + '.' + action + '.' + memberAccess;
+
           const input = captureToInput(field);
           inputsFromContext.push({ input: input, field: field });
 
-          return input;
+          const operator = memberAndOutputAccess.indexOf('?.') > 0 ? '?.' : '.';
+
+          return outputAccess ? input + operator + outputAccess : input;
         }
         throw new Error(`${name} (${name + rest}) not found in ` +
           `symbol table ${pretty(symbolTable)} or context ${pretty(context)}`);


### PR DESCRIPTION
In addition:
- A test case was updated
- A new test case was added to reflect the issue of the output of an action not being able to be accessed when they were the inputs of nested actions.