### PR TITLE
Check for the `setOnInsert` flag in `getLockForUpdate`

### DIFF
--- a/packages/cliche-server/src/db/dbWithPendingLocks.ts
+++ b/packages/cliche-server/src/db/dbWithPendingLocks.ts
@@ -498,7 +498,7 @@ export class CollectionWithPendingLocks<T> implements Collection<T> {
     upsertOptions: UpsertOptions = { upsert: false },
     updateMany: boolean = false): Promise<void> {
     return await this.getLockAndUpdate(context, filter, updateType,
-      { $setOnInsert: upsertOptions.setOnInsert || {} },
+      upsertOptions.setOnInsert ? { $setOnInsert: upsertOptions.setOnInsert } : {},
       { upsert: upsertOptions.upsert }, updateMany);
   }
 


### PR DESCRIPTION
I was trying to use the `deleteMany` function and got the following error:
```
MongoError: '$setOnInsert' is empty. You must specify a field like so: {$setOnInsert: {<field>: ...}}
```
After talking to @mcslao, she suggested this fix. I've tested it locally and it works.