### PR TITLE
Add necessary ModuleWithProviders import to rating.metadata.ts

### DIFF
--- a/packages/catalog/rating/src/app/rating/rating.metadata.ts
+++ b/packages/catalog/rating/src/app/rating/rating.metadata.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+// import required for packaging
 import { ModuleWithProviders } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {


### PR DESCRIPTION
I removed this import in a previous PR because it was seemingly unused within the file, but it is apparently necessary to package and install the cliche.