### PR TITLE
Fix @types/node version in app blueprints

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "fs-extra": "^6.0.1",
-    "rimraf": "^2.6.2",
-    "ohm-js": "^0.14.0"
+    "ohm-js": "^0.14.0",
+    "rimraf": "^2.6.2"
   },
   "peerDepencies": {
     "lodash": "^4.17.4"

--- a/packages/compiler/src/app/builders/blueprints/package.blueprint.json
+++ b/packages/compiler/src/app/builders/blueprints/package.blueprint.json
@@ -39,7 +39,7 @@
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",
     "@deja-vu/cli": "0.0.1",
-    "@types/node": "~6.0.60",
+    "@types/node": "^9.3.0",
     "@types/lodash": "^4.14.96",
     "concurrently": "^3.5.1",
     "ts-node": "~4.1.0",


### PR DESCRIPTION
@maryam-a reported that apps like `hackernews` throw this error when they are run:
```
ERROR in ../../../node_modules/@types/mongodb/index.d.ts(35,10): error TS2305: Module '"tls"' has no exported member 'checkServerIdentity'.
```

This is likely due to the update to`@types/mongodb` in this commit:
https://github.com/spderosso/deja-vu/commit/744dc2bfcb2b208d36918ebbd2bd3f632030d28e#diff-1d0dbfea42ef2783c1536bf2723506a9

It seems like `compiler/` uses `"@types/node": "^9.3.0"` already so it makes sense to update the app blueprints to that version as well and that fixes the above problem.

@maryam-a could you check and make sure that it works on your machine as well?
