### PR TITLE
Fix commit and abort phases of insertOne in db layer

### DIFF
--- a/packages/cliche-server/src/db/dbWithPendingLocks.ts
+++ b/packages/cliche-server/src/db/dbWithPendingLocks.ts
@@ -323,6 +323,9 @@ export class CollectionWithPendingLocks<T> implements Collection<T> {
       case 'commit':
         // release lock/remove pending fields
         // to indicate that the document is now actually created
+        // cannot use the doc's id as filter here and in abort
+        // because it could be different from the unique id
+        // generated for the vote phase
         await this.releaseLock(context, {});
         break;
       case 'abort':


### PR DESCRIPTION
The db layer's insertOne was incorrectly using `doc` as a filter to `commit` (removing the lock on the doc) and to `abort` (deleting the doc). The problem with this is that the `id` field in `doc` could be different for each phase of the 2pc. Since it doesn't keep track of what the id generated in the `vote` phase was, we cannot use the `id` in the `commit`/`abort` phases.