### PR TITLE
Fix upsert bug in db

### DIFF
--- a/packages/cliche-server/src/db/dbWithPendingLocks.ts
+++ b/packages/cliche-server/src/db/dbWithPendingLocks.ts
@@ -552,6 +552,9 @@ export class CollectionWithPendingLocks<T> implements Collection<T> {
         type: `${updateType}-${this._name}`
       }
     }};
+    
+    // if there's nothing to update, then return
+    if (_.isEmpty(updateSetOp) && _.isEmpty(update)) { return; }
 
     const updateResult = await this._update({
       filter,


### PR DESCRIPTION
The `attachLabelsToItem` mutation in the `label` cliche uses upserts, which is why an error was being thrown when trying to create an event in Rendezvous. The relevant action worked fine in the cliche app because it wasn't wrapped in a transaction.

@mcslao suggested this fix and I verified that it works in the Rendezvous app.