### PR TITLE
Phoenix Done with omitted features

### DIFF
--- a/samples/listify/src/list-option/list-option.component.html
+++ b/samples/listify/src/list-option/list-option.component.html
@@ -15,8 +15,6 @@
   </div>
 
   <div class="list-option-description">
-    <dv.if condition=$description>
-      <dv.show-entity entity=$description />
-    </dv.if>
+    <dv.if condition=$description>{{description}}</dv.if>
   </div>
 </dv.action>

--- a/samples/listify/src/profile-card/profile-card.component.html
+++ b/samples/listify/src/profile-card/profile-card.component.html
@@ -2,9 +2,7 @@
   <div class="card-container">
     <div class="profile-card-filler"></div>
     <img src="assets/profile-icon.svg" class="profile-image" />
-    <dv.if condition=$username><p class="username">
-      @<dv.show-entity entity=$username />
-    </p></dv.if>
+    <dv.if condition=$username><p class="username">@{{username}}</p></dv.if>
     <div class="stats-container">
       <div>
         <p class="stats-header">Lists Created</p>
@@ -12,7 +10,7 @@
       </div>
       <dv.if condition=$rankingsSubmitted || $rankingsSubmitted === 0>
         <p class="stats-header">Rankings Submitted</p>
-        <p><dv.show-entity entity=$rankingsSubmitted/></p>
+        <p>{{rankingsSubmitted}}</p>
       </dv.if>
     </div>
   </div>

--- a/samples/listify/src/ranking-info-card/ranking-info-card.component.html
+++ b/samples/listify/src/ranking-info-card/ranking-info-card.component.html
@@ -6,9 +6,7 @@
     <span>This is the consensus ranking for <list.show-object
         class="inline-block"
         object=list.show-object.loadedObject
-        showOnly=['name'] /> according to
-      <dv.show-entity entity=$listVotes />
-        vote(s).
+        showOnly=['name'] /> according to {{listVotes}} vote(s).
       <dv.if condition=list.show-object.loadedObject?.locked>
        Voting has finished for this list.
       </dv.if>


### PR DESCRIPTION
New features: 
- Update personal information (property-update-object)
- Indicate when you are ready to make connections
- Limit input length (general)

Omitted features:
- Filter journal entries by username (filter cliche)
- Positions (possibly label cliche or property containing topics and positions)
- Send email to connection (email cliche)
- Suggestions should be based on some choice of topics and/ positions, location and availability (filter cliche)
- Update topics (labels-update-labels)
- Show when the connection was made and ended (log cliche)
- Sort journal entries by username, when connection was made (sort/log cliche)

For the filter features, we only have `property-filter-objects` and non of the things we want to filter here are properties so there's no existing cliche actions to use. I can implement them but I sense that it might be better to check the other apps first. If you would like me to implement `authentication-filter-username` I can also do it. 